### PR TITLE
Added a read group validation task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.2 - 2024-04-23
+- Added a task to validate the read group string, readGroupCheck
+- Made readGroups a workflow-level input
+
 ## 2.2.1 - 2023-05-24
 - add optional parameter numReads
 - use python module in countChunkSize

--- a/bwaMem.wdl
+++ b/bwaMem.wdl
@@ -8,6 +8,7 @@ workflow bwaMem {
         Int numChunk = 1
         Boolean doUMIextract = false
         Boolean doTrim = false
+        String readGroups
         String reference
         Int? numReads
     }
@@ -19,6 +20,7 @@ workflow bwaMem {
         numChunk: "Number of chunks to split fastq file [1, no splitting]"
         doUMIextract: "If true, UMI will be extracted before alignment [false]"
         doTrim: "If true, adapters will be trimmed before alignment [false]"
+        readGroups: "The readgroup information to be injected into the bam header"
         reference: "The genome reference build. For example: hg19, hg38, mm10"
         numReads: "Number of reads"
     }
@@ -37,6 +39,12 @@ workflow bwaMem {
 
     String bwaMem_modules = bwaMem_modules_by_genome [ reference ]
     String bwaMem_ref = bwaMemRef_by_genome [ reference ]
+
+    # Validating the read-group information
+    call readGroupCheck {  
+        input: 
+        readGroups = readGroups 
+    }
 
     if (numChunk > 1) {
         call countChunkSize {
@@ -99,6 +107,7 @@ workflow bwaMem {
                 input: 
                 read1s = select_first([adapterTrimming.resultR1, extractUMIs.fastqR1, p.left]),
                 read2s = if (defined(fastqR2)) then select_first([adapterTrimming.resultR2, extractUMIs.fastqR2, p.right]) else fastqR2,
+                readGroups = readGroups,
                 modules = bwaMem_modules,
                 bwaRef = bwaMem_ref
         }    
@@ -184,6 +193,44 @@ workflow bwaMem {
         File? cutAdaptAllLogs = adapterTrimmingLog.allLogs
     }
 }
+
+
+task readGroupCheck { 
+    input { 
+        String readGroups 
+        Int jobMemory = 1
+        Int timeout = 1 
+    } 
+
+    parameter_meta { 
+        readGroups: "The read-group information to be validated" 
+        jobMemory: "Memory allocated for this job" 
+        timeout: "Hours before task timeout" 
+    } 
+
+    command <<< 
+        set -euo pipefail 
+
+        # Split the string into an array 
+        IFS=$'\\t' read -ra readFields <<< ~{readGroups}
+        idPresent=false
+
+        for field in "${readFields[@]}"; do 
+            if [[ $field == ID:* ]]; then idPresent=true; break; fi
+        done 
+
+        # Confirm if string begins with '@RG' and 'ID' field is present
+        if ! [[ ~{readGroups} == @RG* ]] ; then 
+            echo "The read group line is not started with @RG" >&2; exit 1
+        fi
+        if ! $idPresent ; then echo "Missing ID within the read group line" >&2; exit 1 ; fi
+    >>> 
+
+    runtime { 
+    memory: "~{jobMemory} GB" 
+    timeout: "~{timeout}" 
+    } 
+} 
 
 
 task countChunkSize{

--- a/commands.txt
+++ b/commands.txt
@@ -1,6 +1,27 @@
 ## Commands
 This section lists command(s) run by bwaMem workflow
 
+Validate the read group string prior to running the rest of the workflow
+
+```
+        set -euo pipefail 
+
+        # Split the string into an array 
+        IFS=$'\\t' read -ra readFields <<< ~{readGroups}
+        idPresent=false
+
+        for field in "${readFields[@]}"; do 
+            if [[ $field == ID:* ]]; then idPresent=true; break; fi
+        done 
+
+        # Confirm if string begins with '@RG' and 'ID' field is present
+        if ! [[ ~{readGroups} == @RG* ]] ; then 
+            echo "The read group line is not started with @RG" >&2; exit 1
+        fi
+        if ! $idPresent ; then echo "Missing ID within the read group line" >&2; exit 1 ; fi
+```
+
+
 Split the fastq files into chunks to parallelize the alignment (optional).  If requested, subsequent steps will be run on each fastq chunk
 
 ```

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -58,12 +58,14 @@
             "bwaMem.numChunk": null,
             "bwaMem.numReads": null,
             "bwaMem.outputFileNamePrefix": "121005_h804_0096_AD0V4NACXX_PCSI0022C_NoIndex_L006_001",
+            "bwaMem.readGroupCheck.jobMemory": null,
+            "bwaMem.readGroupCheck.timeout": null,   
+            "bwaMem.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",         
             "bwaMem.reference": "hg19",
             "bwaMem.runBwaMem.addParam": null,
             "bwaMem.runBwaMem.bwaRef": null,
             "bwaMem.runBwaMem.jobMemory": null,
             "bwaMem.runBwaMem.modules": null,
-            "bwaMem.runBwaMem.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
             "bwaMem.runBwaMem.threads": null,
             "bwaMem.runBwaMem.timeout": null,
             "bwaMem.slicerR1.jobMemory": null,
@@ -117,7 +119,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem/2.2.1/output_metrics/PCSI0022C_notrim_nosplit_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem/2.2.2/output_metrics/PCSI0022C_notrim_nosplit_bam.metrics",
                 "type": "script"
             }
         ]
@@ -181,12 +183,14 @@
             "bwaMem.numChunk": null,
             "bwaMem.numReads": null,
             "bwaMem.outputFileNamePrefix": "121005_h804_0096_AD0V4NACXX_PCSI0022C_NoIndex_L006_001",
+            "bwaMem.readGroupCheck.jobMemory": null,
+            "bwaMem.readGroupCheck.timeout": null,
+            "bwaMem.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
             "bwaMem.reference": "hg19",
             "bwaMem.runBwaMem.addParam": null,
             "bwaMem.runBwaMem.bwaRef": null,
             "bwaMem.runBwaMem.jobMemory": null,
             "bwaMem.runBwaMem.modules": null,
-            "bwaMem.runBwaMem.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
             "bwaMem.runBwaMem.threads": null,
             "bwaMem.runBwaMem.timeout": null,
             "bwaMem.slicerR1.jobMemory": null,
@@ -240,7 +244,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem/2.2.1/output_metrics/PCSI0022C_trim_nosplit_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem/2.2.2/output_metrics/PCSI0022C_trim_nosplit_bam.metrics",
                 "type": "script"
             }
         ]
@@ -304,12 +308,14 @@
             "bwaMem.numChunk": 4,
             "bwaMem.numReads": null,
             "bwaMem.outputFileNamePrefix": "121005_h804_0096_AD0V4NACXX_PCSI0022C_NoIndex_L006_001",
+            "bwaMem.readGroupCheck.jobMemory": null,
+            "bwaMem.readGroupCheck.timeout": null,
+            "bwaMem.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",   
             "bwaMem.reference": "hg19",
             "bwaMem.runBwaMem.addParam": null,
             "bwaMem.runBwaMem.bwaRef": null,
             "bwaMem.runBwaMem.jobMemory": null,
             "bwaMem.runBwaMem.modules": null,
-            "bwaMem.runBwaMem.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
             "bwaMem.runBwaMem.threads": null,
             "bwaMem.runBwaMem.timeout": null,
             "bwaMem.slicerR1.jobMemory": null,
@@ -363,7 +369,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem/2.2.1/output_metrics/PCSI0022C_trim_split_hg19_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem/2.2.2/output_metrics/PCSI0022C_trim_split_hg19_bam.metrics",
                 "type": "script"
             }
         ]
@@ -427,12 +433,14 @@
             "bwaMem.numChunk": 4,
             "bwaMem.numReads": null,
             "bwaMem.outputFileNamePrefix": "121005_h804_0096_AD0V4NACXX_PCSI0022C_NoIndex_L006_001", 
+            "bwaMem.readGroupCheck.jobMemory": null,
+            "bwaMem.readGroupCheck.timeout": null,
+            "bwaMem.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'", 
             "bwaMem.reference": "hg19",
             "bwaMem.runBwaMem.addParam": null,
             "bwaMem.runBwaMem.bwaRef": null,
             "bwaMem.runBwaMem.jobMemory": null,
             "bwaMem.runBwaMem.modules": null,
-            "bwaMem.runBwaMem.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
             "bwaMem.runBwaMem.threads": null,
             "bwaMem.runBwaMem.timeout": null,
             "bwaMem.slicerR1.jobMemory": null,
@@ -486,7 +494,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem/2.2.1/output_metrics/PCSI0022C_notrim_split_hg19_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem/2.2.2/output_metrics/PCSI0022C_notrim_split_hg19_bam.metrics",
                 "type": "script"
             }
         ]
@@ -549,13 +557,15 @@
             "bwaMem.indexBam.timeout": null,
             "bwaMem.numChunk": 4,
             "bwaMem.numReads": null,
-            "bwaMem.outputFileNamePrefix": "121005_h804_0096_AD0V4NACXX_PCSI0022C_NoIndex_L006_001",      
+            "bwaMem.outputFileNamePrefix": "121005_h804_0096_AD0V4NACXX_PCSI0022C_NoIndex_L006_001", 
+            "bwaMem.readGroupCheck.jobMemory": null,
+            "bwaMem.readGroupCheck.timeout": null,    
+            "bwaMem.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",    
             "bwaMem.reference": "hg38",
             "bwaMem.runBwaMem.addParam": null,
             "bwaMem.runBwaMem.bwaRef": null,
             "bwaMem.runBwaMem.jobMemory": null,
             "bwaMem.runBwaMem.modules": null,
-            "bwaMem.runBwaMem.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
             "bwaMem.runBwaMem.threads": null,
             "bwaMem.runBwaMem.timeout": null,
             "bwaMem.slicerR1.jobMemory": null,
@@ -609,7 +619,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem/2.2.1/output_metrics/PCSI0022C_trim_split_hg38_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem/2.2.2/output_metrics/PCSI0022C_trim_split_hg38_bam.metrics",
                 "type": "script"
             }
         ]
@@ -661,13 +671,15 @@
             "bwaMem.indexBam.timeout": null,
             "bwaMem.numChunk": 4,
             "bwaMem.numReads": null,
-            "bwaMem.outputFileNamePrefix": "121005_h804_0096_AD0V4NACXX_PCSI0022C_NoIndex_L006_001",     
+            "bwaMem.outputFileNamePrefix": "121005_h804_0096_AD0V4NACXX_PCSI0022C_NoIndex_L006_001",
+            "bwaMem.readGroupCheck.jobMemory": null,
+            "bwaMem.readGroupCheck.timeout": null,
+            "bwaMem.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",   
             "bwaMem.reference": "hg19",
             "bwaMem.runBwaMem.addParam": null,
             "bwaMem.runBwaMem.bwaRef": null,
             "bwaMem.runBwaMem.jobMemory": null,
             "bwaMem.runBwaMem.modules": null,
-            "bwaMem.runBwaMem.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
             "bwaMem.runBwaMem.threads": null,
             "bwaMem.runBwaMem.timeout": null,
             "bwaMem.slicerR1.jobMemory": null,
@@ -721,7 +733,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem/2.2.1/output_metrics/PCSI0022C_trim_split_hg19_bam_se.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem/2.2.2/output_metrics/PCSI0022C_trim_split_hg19_bam_se.metrics",
                 "type": "script"
             }
         ]
@@ -774,12 +786,14 @@
             "bwaMem.numChunk": null,
             "bwaMem.numReads": null,
             "bwaMem.outputFileNamePrefix": "121005_h804_0096_AD0V4NACXX_PCSI0022C_NoIndex_L006_001",
+            "bwaMem.readGroupCheck.jobMemory": null,
+            "bwaMem.readGroupCheck.timeout": null,
+            "bwaMem.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'", 
             "bwaMem.reference": "hg19",
             "bwaMem.runBwaMem.addParam": null,
             "bwaMem.runBwaMem.bwaRef": null,
             "bwaMem.runBwaMem.jobMemory": null,
             "bwaMem.runBwaMem.modules": null,
-            "bwaMem.runBwaMem.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
             "bwaMem.runBwaMem.threads": null,
             "bwaMem.runBwaMem.timeout": null,
             "bwaMem.slicerR1.jobMemory": null,
@@ -833,7 +847,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem/2.2.1/output_metrics/PCSI0022C_trim_nosplit_hg19_bam_se.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem/2.2.2/output_metrics/PCSI0022C_trim_nosplit_hg19_bam_se.metrics",
                 "type": "script"
             }
         ]
@@ -885,13 +899,15 @@
             "bwaMem.indexBam.timeout": null,
             "bwaMem.numChunk": null,
             "bwaMem.numReads": null,
-            "bwaMem.outputFileNamePrefix": "121005_h804_0096_AD0V4NACXX_PCSI0022C_NoIndex_L006_001",   
+            "bwaMem.outputFileNamePrefix": "121005_h804_0096_AD0V4NACXX_PCSI0022C_NoIndex_L006_001",
+            "bwaMem.readGroupCheck.jobMemory": null,
+            "bwaMem.readGroupCheck.timeout": null,
+            "bwaMem.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",  
             "bwaMem.reference": "hg19",
             "bwaMem.runBwaMem.addParam": null,
             "bwaMem.runBwaMem.bwaRef": null,
             "bwaMem.runBwaMem.jobMemory": null,
             "bwaMem.runBwaMem.modules": null,
-            "bwaMem.runBwaMem.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
             "bwaMem.runBwaMem.threads": null,
             "bwaMem.runBwaMem.timeout": null,
             "bwaMem.slicerR1.jobMemory": null,
@@ -945,7 +961,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem/2.2.1/output_metrics/PCSI0022C_notrim_nosplit_hg19_bam_se.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem/2.2.2/output_metrics/PCSI0022C_notrim_nosplit_hg19_bam_se.metrics",
                 "type": "script"
             }
         ]
@@ -1008,13 +1024,15 @@
             "bwaMem.indexBam.timeout": null,
             "bwaMem.numChunk": 4,
             "bwaMem.numReads": null,
-            "bwaMem.outputFileNamePrefix": "121005_h804_0096_AD0V4NACXX_PCSI0022C_NoIndex_L006_001",      
+            "bwaMem.outputFileNamePrefix": "121005_h804_0096_AD0V4NACXX_PCSI0022C_NoIndex_L006_001",
+            "bwaMem.readGroupCheck.jobMemory": null,
+            "bwaMem.readGroupCheck.timeout": null,
+            "bwaMem.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",    
             "bwaMem.reference": "hg19",
             "bwaMem.runBwaMem.addParam": null,
             "bwaMem.runBwaMem.bwaRef": null,
             "bwaMem.runBwaMem.jobMemory": null,
             "bwaMem.runBwaMem.modules": null,
-            "bwaMem.runBwaMem.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
             "bwaMem.runBwaMem.threads": null,
             "bwaMem.runBwaMem.timeout": null,
             "bwaMem.slicerR1.jobMemory": null,
@@ -1068,7 +1086,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem/2.2.1/output_metrics/PCSI0022C_umi_adapter_trim_split_hg19_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem/2.2.2/output_metrics/PCSI0022C_umi_adapter_trim_split_hg19_bam.metrics",
                 "type": "script"
             }
         ]
@@ -1131,13 +1149,15 @@
             "bwaMem.indexBam.timeout": null,
             "bwaMem.numChunk": 4,
             "bwaMem.numReads": 3713,
-            "bwaMem.outputFileNamePrefix": "121005_h804_0096_AD0V4NACXX_PCSI0022C_NoIndex_L006_001",      
+            "bwaMem.outputFileNamePrefix": "121005_h804_0096_AD0V4NACXX_PCSI0022C_NoIndex_L006_001",
+            "bwaMem.readGroupCheck.jobMemory": null,
+            "bwaMem.readGroupCheck.timeout": null,
+            "bwaMem.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
             "bwaMem.reference": "hg38",
             "bwaMem.runBwaMem.addParam": null,
             "bwaMem.runBwaMem.bwaRef": null,
             "bwaMem.runBwaMem.jobMemory": null,
             "bwaMem.runBwaMem.modules": null,
-            "bwaMem.runBwaMem.readGroups": "'@RG\\tID:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tLB:PCSI0022C\\tPL:ILLUMINA\\tPU:121005_h804_0096_AD0V4NACXX-NoIndex_6\\tSM:PCSI0022C'",
             "bwaMem.runBwaMem.threads": null,
             "bwaMem.runBwaMem.timeout": null,
             "bwaMem.slicerR1.jobMemory": null,
@@ -1191,7 +1211,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem/2.2.1/output_metrics/PCSI0022C_trim_split_hg38_numRead_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem/2.2.2/output_metrics/PCSI0022C_trim_split_hg38_numRead_bam.metrics",
                 "type": "script"
             }
         ]
@@ -1255,12 +1275,14 @@
             "bwaMem.numChunk": null,
             "bwaMem.numReads": null,
             "bwaMem.outputFileNamePrefix": "neat_5x_EX_hg19_golden",
+            "bwaMem.readGroupCheck.jobMemory": null,
+            "bwaMem.readGroupCheck.timeout": null,
+            "bwaMem.readGroups": "'@RG\\tID:1\\tLB:neat_5x_EX_hg19_golden\\tPL:illumina\\tPU:run_barcode\\tSM:neat_5x_EX_hg19_golden'",  
             "bwaMem.reference": "hg19",
             "bwaMem.runBwaMem.addParam": null,
             "bwaMem.runBwaMem.bwaRef": null,
             "bwaMem.runBwaMem.jobMemory": null,
             "bwaMem.runBwaMem.modules": null,
-            "bwaMem.runBwaMem.readGroups": "'@RG\\tID:1\\tLB:neat_5x_EX_hg19_golden\\tPL:illumina\\tPU:run_barcode\\tSM:neat_5x_EX_hg19_golden'",
             "bwaMem.runBwaMem.threads": null,
             "bwaMem.runBwaMem.timeout": null,
             "bwaMem.slicerR1.jobMemory": null,
@@ -1314,7 +1336,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem/2.2.1/output_metrics/neat_5x_umi_extract_nosplit_hg19_bam.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bwamem/2.2.2/output_metrics/neat_5x_umi_extract_nosplit_hg19_bam.metrics",
                 "type": "script"
             }
         ]


### PR DESCRIPTION
Added a task, readGroupCheck, which ensures that the read group string is in the correct format for bwa mem. Based on testing, I confirmed that bwa mem stops with an error if:

(1) If the read group string does not start with @RG
(2) If there is no ID field

Bwa-mem does not check if the other fields conform to the SAM specifications. The task checks if the readGroup string adheres to these two requirements before running the rest of the workflow. 

Also converted readGroups into a workflow-level input, rather than a task-level one.
